### PR TITLE
comment out transform declarations

### DIFF
--- a/docs/files/cleanslate.css
+++ b/docs/files/cleanslate.css
@@ -143,11 +143,16 @@
     text-shadow: none !important;
     -webkit-transition: all 0s ease 0s !important;
             transition: all 0s ease 0s !important;
-    -webkit-transform: none !important;
+
+    /* transform commented out because it was overriding 
+    our typing indicator animation in Firefox */
+
+    /* -webkit-transform: none !important;
        -moz-transform: none !important;
         -ms-transform: none !important;
          -o-transform: none !important;
-            transform: none !important;
+            transform: none !important; */ 
+            
     -webkit-transform-origin: 50% 50% !important;
        -moz-transform-origin: 50% 50% !important;
         -ms-transform-origin: 50% 50% !important;


### PR DESCRIPTION
## What 

Removing transform declarations from Cleanslate

## Why

Cleanslate's `transform: none !important` is overriding the typing indicator animation keyframe transform declarations.

Heres part of the CSS animation that makes the typing indicator bounce:

```
@keyframes wave {
  0%, 60%, 100% {
    transform: initial !important;
  }
  30% {
    transform: translateY(-3px) !important;
  }
  85% {
    transform: translateY(1px) !important;
  }
}
```

From MDN: "Declarations in a keyframe qualified with !important are ignored."

The animation is playing on all browsers (Chrome, IE11, Safari) except for Firefox. This is because most browsers allow animations of properties that have been previously qualified with !important whereas Firefox does not allow animations of declarations previously qualified with !important


## Testing

Test out the typing indicator in Firefox browser by chatting in and having the agent respond. Note that the animation is moving. 