### PR TITLE
adding font-style: italic to the <i/> tag to fix italics in sidekick answers

### DIFF
--- a/cleanslate.css
+++ b/cleanslate.css
@@ -143,15 +143,15 @@
     text-shadow: none !important;
     -webkit-transition: all 0s ease 0s !important;
             transition: all 0s ease 0s !important;
-            
-/* transform commented out because it overrides 
+
+/* transform commented out because it overrides
      typing indicator animation in Firefox */
 
     /* -webkit-transform: none !important;
        -moz-transform: none !important;
         -ms-transform: none !important;
          -o-transform: none !important;
-            transform: none !important; */ 
+            transform: none !important; */
 
     -webkit-transform-origin: 50% 50% !important;
        -moz-transform-origin: 50% 50% !important;
@@ -259,7 +259,7 @@
 .cleanslate strong {
     font-weight:bold !important;
 }
-.cleanslate em {
+.cleanslate em, i {
     font-style:italic !important;
 }
 .cleanslate kbd, .cleanslate samp, .cleanslate code, .cleanslate pre {


### PR DESCRIPTION
## What 
Italics aren't coming through in the sidekick because the style is only associated with `<em/>` instead of the `<i/>` tag that we export from AD. This should fix all instances of italics issues in the widget. 

## Why 
To allow for italic text

## Testing 
N/A

## pics 
The em tag has the requisite styling, so updating the italics will fix it 

![image](https://user-images.githubusercontent.com/8879232/65179510-cc644a00-da0f-11e9-8194-6a9b3d5dc7e7.png)
